### PR TITLE
Fix parsing algorithm for Access Control Expose Headers (ACEH)

### DIFF
--- a/cors/resources/access-control-expose-headers.json
+++ b/cors/resources/access-control-expose-headers.json
@@ -33,7 +33,7 @@
   },
   {
     "input": "Access-Control-Expose-Headers: ,bb-8",
-    "exposed": false
+    "exposed": true
   },
   {
     "input": "Access-Control-Expose-Headers: bb-8\u000C",


### PR DESCRIPTION
This CL fixes the implementation for parsing ACEH values to pass the two failed WPT.

```
{
  "input": "Access-Control-Expose-Headers:\r\nAccess-Control-Expose-Headers: bb-8",
  "exposed": true
},
{
  "input": "Access-Control-Expose-Headers: ,bb-8",
  "exposed": true
},
```

According to the Fetch Standard [1], the first test case is interpreted as below and it's the same as the second test case.

```
Access-Control-Expose-Headers: ,bb-8",
```

The Fetch Standard says the parsing ACEH algorithm follows the RFC 7230 [2].  And in RFC 7230, the empty element must be accepted and ignored for legacy list rules [3].

> For compatibility with legacy list rules, a recipient MUST parse and
> ignore a reasonable number of empty list elements

[1] https://fetch.spec.whatwg.org/#example-header-list-get-decode-split
[2] https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list
[3] https://datatracker.ietf.org/doc/html/rfc7230#section-7

Bug: 978146
Change-Id: Ic7a379c4bb0189299d0d64156173c3cc02a80323