### PR TITLE
Ensure visibilityState gets updated before pagehide & pageshow

### DIFF
--- a/page-visibility/resources/visibility-on-pagehide.html
+++ b/page-visibility/resources/visibility-on-pagehide.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<body>
+<script>
+window.onload = function() {
+  window.addEventListener("pagehide", () => {
+    opener.postMessage(document.visibilityState, "*");
+  });
+  opener.postMessage("loaded", "*");
+}
+</script>
+</body>
+</html>

--- a/page-visibility/resources/visibility-on-pageshow.html
+++ b/page-visibility/resources/visibility-on-pageshow.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<body>
+<script>
+window.addEventListener("pageshow", () => {
+  opener.postMessage(document.visibilityState, "*");
+});
+</script>
+</body>
+</html>

--- a/page-visibility/visibility-on-pagehide.html
+++ b/page-visibility/visibility-on-pagehide.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>Tests that visibilityState == hidden when pagehide is fired</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+async_test(function(t) {
+  var w = window.open("resources/visibility-on-pagehide.html");
+  window.onmessage = t.step_func(function(event) {
+    if (event.data === "loaded") {
+      // The opened window finished loading. Close it to trigger pagehide.
+      w.close();
+      return;
+    }
+    // Check that the visibilityState value when pagehide was fired on the
+    // opened window is "hidden".
+    assert_equals(event.data, "hidden");
+    t.done();
+  });
+});
+</script>

--- a/page-visibility/visibility-on-pageshow.html
+++ b/page-visibility/visibility-on-pageshow.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Tests that visibilityState == visible when pageshow is fired</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  var w = window.open("resources/visibility-on-pageshow.html");
+  window.onmessage = t.step_func(function(event) {
+    // Check that the visibilityState value when pageshow was fired on the
+    // opened window is "visible".
+    assert_equals(event.data, "visible");
+    t.done();
+  });
+});
+</script>


### PR DESCRIPTION
Currently when unloading a document, we would fire pagehide before updating visibility and firing visibilitychange. This CL swaps this ordering so that we would fire visibilitychange before pagehide per the spec change at https://github.com/whatwg/html/pull/5928.

This CL also ensures visibilitychange fires before pageshow to follow the spec at https://html.spec.whatwg.org/multipage/browsing-the-web.html#session-history-document-visibility-change-steps

I2S: https://groups.google.com/a/chromium.org/g/blink-dev/c/R7h6InVXzcI/m/FNSaab_GCAAJ

Bug: 1130950
Change-Id: Iaa23d14fe7b22b16af661b573a5f617530dc2303