### PR TITLE
[mathml] Fix ignored-properties-001.html

### DIFF
--- a/mathml/relations/css-styling/ignored-properties-001.html
+++ b/mathml/relations/css-styling/ignored-properties-001.html
@@ -29,9 +29,6 @@
               "align-content: end; justify-content: end;",
               "align-self: end; justify-self: end;",
           ];
-          if (tag !== "mtable") {
-              ignoredProperties.push("width: 100px !important; height: 200px !important;");
-          }
 
           ignoredProperties.forEach(ignoredStyle => {
               document.body.insertAdjacentHTML("beforeend", `<div style="position: absolute;">\


### PR DESCRIPTION
The width/height properties are no longer ignored so do not test them as ignored properties.
Also use padding-left/padding-right for fractions since this ignores writing mode.

Bug: 6606

Change-Id: I107a925bc5d3ae1365e1884875f8dbff26a25769