### PR TITLE
Window Placement: Enable runtime features by default

### DIFF
--- a/speculation-rules/prerender/resources/window-move.html
+++ b/speculation-rules/prerender/resources/window-move.html
@@ -23,7 +23,7 @@ function tryRun(func) {
 if (!isPrerendering) {
   // Ensure that the primary page can move this window.
   tryRun(() => {
-    const expectedPosition = {x: window.screenX + 1, y: window.screenY + 1};
+    const expectedPosition = {x: screen.availLeft + 1, y: screen.availTop + 1};
     window.moveTo(expectedPosition.x, expectedPosition.y);
     assert_equals(window.screenX, expectedPosition.x, 'x position for primary');
     assert_equals(window.screenY, expectedPosition.y, 'y position for primary');

--- a/window-placement/multi-screen-window-open-manual.tentative.https.html
+++ b/window-placement/multi-screen-window-open-manual.tentative.https.html
@@ -33,6 +33,24 @@ cleanUpButton.addEventListener('click', async () => {
   popups.forEach(p => p.close());
 });
 
+function checkPopupPlacement(popup, x, y, allowSameScreenClamping) {
+  // Window.screenX|Y may be zero, if the user agent wishes to hide information
+  // about the screen of the output device. They also may incorrectly reflect
+  // the origin of content viewport; in that case, estimate window coordinates
+  // by subtracing estimated frame insets (top-heavy, horizontally centered).
+  // Synchronous estimated placements may be clamped to the current screen.
+  const error = 10;
+  const dX = popup.screenX - x - (popup.outerWidth - popup.innerWidth) / 2;
+  const dY = popup.screenY - y - (popup.outerHeight - popup.innerHeight);
+
+  assert_true(!popup.screenX || popup.screenX == x || Math.abs(dX) <= error ||
+              (allowSameScreenClamping && popup.screenX > screen.availLeft &&
+               popup.screenX < screen.availLeft + screen.availWidth));
+  assert_true(!popup.screenY || popup.screenY == y || Math.abs(dY) <= error ||
+              (allowSameScreenClamping && popup.screenY > screen.availTop &&
+               popup.screenY < screen.availTop + screen.availHeight));
+}
+
 async function testPopupOnScreen(popupTest, screen) {
   // Show a popup child window on the associated screen.
   const left = screen.availLeft + Math.floor(screen.availWidth / 2) - 150;
@@ -50,8 +68,8 @@ async function testPopupOnScreen(popupTest, screen) {
   log(`<div style='margin-left: 40px'>Initial bounds:
          (${popup.screenX}, ${popup.screenY})
        </div>`);
-  assert_equals(popup.screenX, left);
-  assert_equals(popup.screenY, top);
+  // Allow synchronous estimated placements to be clamped to the current screen.
+  checkPopupPlacement(popup, left, top, true);
   popup.initialScreenX = popup.screenX;
   popup.initialScreenY = popup.screenY;
 
@@ -70,15 +88,8 @@ async function testPopupOnScreen(popupTest, screen) {
   log(`<div style='margin-left: 40px'>Resolved bounds:
          (${popup.screenX}, ${popup.screenY})
        </div>`);
-  // Window.screenX|Y may be zero, if the user agent wishes to hide information
-  // about the screen of the output device. They also may incorrectly reflect
-  // the origin of content viewport; in that case, estimate window coordinates
-  // by subtracing estimated frame insets (top-heavy, horizontally centered).
-  const error = 10;
-  const dX = popup.screenX - left - (popup.outerWidth - popup.innerWidth) / 2;
-  const dY = popup.screenY - top - (popup.outerHeight - popup.innerHeight);
-  assert_true(!popup.screenX || popup.screenX == left || Math.abs(dX) <= error);
-  assert_true(!popup.screenY || popup.screenY == top || Math.abs(dY) <= error);
+  // Do not allow resolved placements to be clamped to the current screen.
+  checkPopupPlacement(popup, left, top, false);
 }
 
 promise_test(async setUpTest => {


### PR DESCRIPTION
1) Mark the WindowPlacement RuntimeEnabledFeature as stable. (The API launch has been approved for M100 Beta)

2) Tweak Blink's estimated and preemptive window rect clamping:
- Perform legacy clamping and adjustment of all pending window rects. (yields synchronous estimates of screenX|Y... from open, moveTo, etc.) (clamps to same-screen, since permission info isn't readily available)
- Pass original (not clamped nor adjusted) window rects to the browser. (which adjusts while honoring permission-gated cross-screen requests)

3) Update and re-baseline web platform tests.

FOLLOWUP: Use permission state for better sync estimates in Blink (or store unadjusted pending rects if that won't break many sites)

Bug: 897300, 1255960
Test: Automated; window-placement is enabled by default.
Change-Id: I69e3a624af7e7d7722a065b34c209888c7c461f1