### PR TITLE
[Not for landing] Enable synchronous parser by default for tests

### DIFF
--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
@@ -6,7 +6,7 @@
     <script src='/resources/testharness.js' nonce='dummy'></script>
     <script src='/resources/testharnessreport.js' nonce='dummy'></script>
 
-    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o=' -->
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' -->
 </head>
 
 <body>
@@ -16,7 +16,7 @@
     <script nonce='dummy'>
         var hashScriptRan = false;
         window.addEventListener('securitypolicyviolation', function(e) {
-            assert_unreached('No CSP violation report has fired.');
+            assert_unreached('CSP violation reports should not fire.');
         });
     </script>
 
@@ -32,7 +32,7 @@
         }, "Script matching SHA256 hash is allowed with `strict-dynamic`.");
     </script>
 
-    <!-- Hash: 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o=' -->
+    <!-- Hash: 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA=' -->
     <script>
         async_test(function(t) {
             window.addEventListener('message', t.step_func(function(e) {

--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
@@ -2,4 +2,4 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o='
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-EEoi70frWHkGFhK51NVIJkXpq72aPxSCNZEow37ZmRA='

--- a/html/semantics/embedded-content/the-img-element/invisible-image.html
+++ b/html/semantics/embedded-content/the-img-element/invisible-image.html
@@ -28,54 +28,50 @@
        loading="eager">
   <script>
     document.getElementById("js_display_none").style = 'display:none;';
+    const visibility_hidden_element = document.getElementById("visibility_hidden");
+    const visibility_hidden_element_explicit_eager =
+      document.getElementById("visibility_hidden_explicit_eager");
+
+    const display_none_element = document.getElementById("display_none");
+    const display_none_element_explicit_eager =
+      document.getElementById("display_none_explicit_eager");
+
+    const attribute_hidden_element = document.getElementById("attribute_hidden");
+    const attribute_hidden_element_explicit_eager =
+      document.getElementById("attribute_hidden_explicit_eager");
+
+    const js_display_none_element = document.getElementById("js_display_none");
+    const js_display_none_element_explicit_eager =
+      document.getElementById("js_display_none_explicit_eager");
+
+    let have_images_loaded = false;
+
+    async_test(t => {
+      let image_fully_loaded_promise = (element) => {
+        return new Promise(resolve => {
+          element.addEventListener("load", t.step_func(resolve));
+        });
+      }
+
+      Promise.all([
+        image_fully_loaded_promise(visibility_hidden_element),
+        image_fully_loaded_promise(visibility_hidden_element_explicit_eager),
+        image_fully_loaded_promise(display_none_element),
+        image_fully_loaded_promise(display_none_element_explicit_eager),
+        image_fully_loaded_promise(attribute_hidden_element),
+        image_fully_loaded_promise(attribute_hidden_element_explicit_eager),
+        image_fully_loaded_promise(js_display_none_element),
+        image_fully_loaded_promise(js_display_none_element_explicit_eager)
+      ]).then(t.step_func(() => {
+        have_images_loaded = true;
+      })).catch(t.unreached_func("All images should load correctly"));
+
+      window.addEventListener("load", t.step_func_done(() => {
+        assert_true(have_images_loaded,
+                    "The images should block the window load event.");
+      }));
+
+    }, "Test that below-viewport invisible images that are not marked " +
+         "loading=lazy still load, and block the window load event");
   </script>
 </body>
-
-<script>
-  const visibility_hidden_element = document.getElementById("visibility_hidden");
-  const visibility_hidden_element_explicit_eager =
-    document.getElementById("visibility_hidden_explicit_eager");
-
-  const display_none_element = document.getElementById("display_none");
-  const display_none_element_explicit_eager =
-    document.getElementById("display_none_explicit_eager");
-
-  const attribute_hidden_element = document.getElementById("attribute_hidden");
-  const attribute_hidden_element_explicit_eager =
-    document.getElementById("attribute_hidden_explicit_eager");
-
-  const js_display_none_element = document.getElementById("js_display_none");
-  const js_display_none_element_explicit_eager =
-    document.getElementById("js_display_none_explicit_eager");
-
-  let have_images_loaded = false;
-
-  async_test(t => {
-    let image_fully_loaded_promise = (element) => {
-      return new Promise(resolve => {
-        element.addEventListener("load", t.step_func(resolve));
-      });
-    }
-
-    Promise.all([
-      image_fully_loaded_promise(visibility_hidden_element),
-      image_fully_loaded_promise(visibility_hidden_element_explicit_eager),
-      image_fully_loaded_promise(display_none_element),
-      image_fully_loaded_promise(display_none_element_explicit_eager),
-      image_fully_loaded_promise(attribute_hidden_element),
-      image_fully_loaded_promise(attribute_hidden_element_explicit_eager),
-      image_fully_loaded_promise(js_display_none_element),
-      image_fully_loaded_promise(js_display_none_element_explicit_eager)
-    ]).then(t.step_func(() => {
-      have_images_loaded = true;
-    })).catch(t.unreached_func("All images should load correctly"));
-
-    window.addEventListener("load", t.step_func_done(() => {
-      assert_true(have_images_loaded,
-                  "The images should block the window load event.");
-    }));
-
-  }, "Test that below-viewport invisible images that are not marked " +
-     "loading=lazy still load, and block the window load event");
-</script>
-


### PR DESCRIPTION
* Toggles the ForceSynchronousHTMLParsing flag on
* Fixes various tests
* Adjusts scheduling to yield both before/after scripts

Bug: 901056
Change-Id: I90f1fd16639e878b55dcd35372c72c0fb1117481