### PR TITLE
Credentialless: basic preliminary implementation.

### DIFF
--- a/html/cross-origin-embedder-policy/credentialless/resources/common.js
+++ b/html/cross-origin-embedder-policy/credentialless/resources/common.js
@@ -5,7 +5,7 @@ const executor_path = directory + '/resources/executor.html?pipe=';
 const coep_none =
     '|header(Cross-Origin-Embedder-Policy,none)';
 const coep_credentialless =
-    '|header(Cross-Origin-Embedder-Policy,credentialless)';
+    '|header(Cross-Origin-Embedder-Policy,cors-or-credentialless)';
 const coep_require_corp =
     '|header(Cross-Origin-Embedder-Policy,require-corp)';
 


### PR DESCRIPTION
Strip cookies for cross-origin non-cors requests initiated from a document using COEP: credentialless.

This is a really basic implementation of COEP: credentialless, which is behind a flag.

Bug: chromium:1175099
Change-Id: I682ad8fc9fadca977c705824c28a2290b916201b